### PR TITLE
Fix compile error about optional value

### DIFF
--- a/Sources/HTMLString/HTMLString.swift
+++ b/Sources/HTMLString/HTMLString.swift
@@ -89,7 +89,7 @@ extension String {
             }
 
             let escapableContent = self[delimiterRange.upperBound ..< semicolonRange.lowerBound]
-            let escapableContentString = String(escapableContent)
+            let escapableContentString = String(escapableContent)!
             let replacementString: String
 
             if escapableContentString.hasPrefix("#") {


### PR DESCRIPTION
This line currently fails to compile if called on a String.UTF8View or String.UTF16View.

String(Substring) always returns a valid value, but String(Substring.UTF8View) or the same for UTF16View will return nil if the argument is not valid UTF8 or UTF16. Since we know self is valid, we can safely assert that a substring of self is valid and that the String initializer will return non-nil.