### PR TITLE
Fix a library-breaking configuration issue for Cocoapods

### DIFF
--- a/HTMLString.podspec
+++ b/HTMLString.podspec
@@ -17,7 +17,7 @@ DESC
   s.tvos.deployment_target = "9.0"
 
   s.source       = { :git => "https://github.com/alexaubry/HTMLString.git", :tag => "#{s.version}" }
-  s.source_files  = "Sources/HTMLString/*.swift"
+  s.source_files  = "{Resources/*.plist,Sources/HTMLString/*.swift}"
   s.documentation_url = "https://alexaubry.github.io/HTMLString/"
 
   s.swift_version = "5.0"


### PR DESCRIPTION
@alexaubry: This podspec as written depends on a git tag for version 5.0.0 which doesn't exist.

The plist file containing all of the entity mappings was not included as a source file in the Podspec, so it does not exist when this library is used via Cocoapods. The [error handling logic][error-handling-logic] silently fails by using an empty unescapingTable and this results in the library failing to unescape strings.

The silent failure should probably be addressed, but for this PR, I'm just going to fix the issue.

[error-handling-logic]: https://github.com/alexaubry/HTMLString/blob/b6f82382bba2b5b9131eb8634d41d19a8968cf20/Sources/HTMLString/Mappings.swift#L27