### PR TITLE
Fix removeHTMLEntities may crash for NSString

### DIFF
--- a/Tests/HTMLStringTests/HTMLStringTests.swift
+++ b/Tests/HTMLStringTests/HTMLStringTests.swift
@@ -79,6 +79,13 @@ class HTMLStringTests: XCTestCase {
         let doubleEmojiEscape = ("Going to the &#127482;&#127480; next June").removingHTMLEntities
         XCTAssertEqual(doubleEmojiEscape, "Going to the 🇺🇸 next June")
     }
+    
+    /// Refer to issue https://github.com/alexaubry/HTMLString/issues/22
+    func testNSString() {
+        let nsSepcialCharacter = NSString("𝟸𝟺𝟶&deg;")
+        let sepcialCharacter = nsSepcialCharacter as String
+        XCTAssertEqual(sepcialCharacter.removingHTMLEntities, "𝟸𝟺𝟶°")
+    }
 
     // MARK: - Open Data
 


### PR DESCRIPTION
Refer to #22, use `String.range` to search `&` character with cause fatal error if that string is converted from `NSString`

This PR is going to fix this issue by using `Substring` and `String.index` to perform character searching, instead of using `String.range`