### PR TITLE
Move method implementations of `HTMLString` into `StringProtocol`.

### DIFF
--- a/Sources/HTMLString/HTMLString.swift
+++ b/Sources/HTMLString/HTMLString.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: Escaping
 
-extension String {
+extension StringProtocol {
 
     ///
     /// Returns a copy of the current `String` where every character incompatible with HTML Unicode
@@ -78,7 +78,7 @@ extension String {
 
 // MARK: - Unescaping
 
-extension String {
+extension StringProtocol {
 
     ///
     /// Replaces every HTML entity in the receiver with the matching Unicode character.


### PR DESCRIPTION
When we get a substring value from a `String` value (using .prefix, .suffix, subscript and so on), we can get the value in `Substring` type. The `Substring` type provide a way to access the substring value without copying the part of string from original value. So, to use `Substring` value directly, we can use the substring more efficiently.

For that reason, I tried to move the method implementations of HTMLString from `String` type to `StringProtocol` protocol. The `StringProtocol` is conformed to both `String` type and `Substring` type. So, to implementing the methods by `StringProtocol` instead of `String`, the methods will belong both `String` and `Substring`. This allows us to use HTMLString methods by `Substring` directly without copying the part of content.